### PR TITLE
feat: Add cached configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ where `KEY` is the control key specified and `MOD` is:
 - <kbd>cmd</kbd>+<kbd>ctrl</kbd> on mac
 - <kbd>super</kbd>+<kbd>ctrl</kbd> or <kbd>alt</kbd> on linux
 
+## reset settings
+to reset settings to the initial configuration, type <kbd>MOD</kbd>+<kbd>c</kbd> at any point in the text box.
+
 ## theme
 
 type the theme (e.g.: `dracula`) in the text box then type <kbd>MOD</kbd>+<kbd>t</kbd>.

--- a/main.js
+++ b/main.js
@@ -1,15 +1,34 @@
 // main.js
 // electron app logic
 
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const fs = require('fs');
+
+// defualt cookie values
+let cookies = {
+  theme: 'light',
+  language: 'english',
+  wordCount: 50,
+  timeCount: 60,
+  typingMode: 'wordcount',
+  punctuation: true,
+};
+
+const cookieDir = path.join(app.getPath('cache'), 'typings-desktop');
+const cookiePath = path.join(cookieDir, 'config.json');
 
 const createWindow = () => {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
   })
 
   win.loadFile('index.html');
+
 }
 
 app.whenReady().then(() => {
@@ -27,3 +46,40 @@ app.on('window-all-closed', () => {
   }
 });
 
+// create cookie file
+try {
+  fs.mkdirSync(cookieDir, {recursive: true});
+  if (!fs.existsSync(cookiePath)) {
+    fs.writeFileSync(cookiePath, JSON.stringify(cookies) + '\n');
+  }
+
+  cookies = {...cookies, ...JSON.parse(fs.readFileSync(cookiePath))};
+  console.log(cookies);
+}
+catch (e) {
+  console.error(e);
+}
+
+// cookie handler
+ipcMain.handle('load-cookies', async (_) => {
+  try {
+    cookies = {...cookies, ...JSON.parse(fs.readFileSync(cookiePath))};
+  }
+  catch (e) {
+    console.error(e);
+  }
+
+  return cookies;
+});
+
+ipcMain.handle('save-cookies', async (_, newCookies) => {
+  try {
+    fs.writeFileSync(cookiePath, JSON.stringify(newCookies) + '\n');
+    cookies = newCookies;
+  }
+  catch (e) {
+    console.error(e);
+  }
+
+  return cookies;
+});

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,17 @@
+// preload.js
+// embed configuration
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  defaultCookies: {
+    theme: 'light',
+    language: 'english',
+    wordCount: 50,
+    timeCount: 60,
+    typingMode: 'wordcount',
+    punctuation: 'false',
+  },
+  loadCookies: () => ipcRenderer.invoke('load-cookies'),
+  saveCookies: (c) => ipcRenderer.invoke('save-cookies', c),
+});


### PR DESCRIPTION
Creates a global `config` variable on the renderer side that communicates with the main process to save JSON configuration between sessions. Data is stored in a `typings-desktop` directory in the path from `app.getPath('cache')`, and can be cleared with <kbd>MOD</kbd>+<kbd>c</kbd> in the test window.